### PR TITLE
Added required package gridPlot to install

### DIFF
--- a/00_sim_basis_and_mrs_data.R
+++ b/00_sim_basis_and_mrs_data.R
@@ -3,8 +3,6 @@ if (!require("pacman")) install.packages("pacman",repos = "http://cran.us.r-proj
 pacman::p_load(spant, logr, cowplot, ggplot2, ggsignif, dplyr, cowplot, 
                parallel, doParallel,gridGraphics)
 
-set_lcm_cmd('/Users/pfuchs/Library/CloudStorage/OneDrive-UniversiteitAntwerpen/Reviews/MRM-24-25374/abfit_reg_paper/')
-
 # create an output dir
 dir.create("synth_data", showWarnings = FALSE)
 

--- a/00_sim_basis_and_mrs_data.R
+++ b/00_sim_basis_and_mrs_data.R
@@ -1,7 +1,9 @@
 # install any necessary packages
-if (!require("pacman")) install.packages("pacman")
+if (!require("pacman")) install.packages("pacman",repos = "http://cran.us.r-project.org")
 pacman::p_load(spant, logr, cowplot, ggplot2, ggsignif, dplyr, cowplot, 
-               parallel, doParallel)
+               parallel, doParallel,gridGraphics)
+
+set_lcm_cmd('/Users/pfuchs/Library/CloudStorage/OneDrive-UniversiteitAntwerpen/Reviews/MRM-24-25374/abfit_reg_paper/')
 
 # create an output dir
 dir.create("synth_data", showWarnings = FALSE)


### PR DESCRIPTION
Script [02_plot_fits.R](https://github.com/martin3141/abfit_reg_paper/blob/main/02_plot_fits.R) fails without this dependency.
Additionally, repos = "http://cran.us.r-project.org" given explicitly in pacman install command to prevent warning when running on a fresh R install.